### PR TITLE
Added banner to tell new project to get verified

### DIFF
--- a/app/assets/stylesheets/_components.css
+++ b/app/assets/stylesheets/_components.css
@@ -50,3 +50,22 @@
 .snapshot-form {
   margin-top: 1rem;
 }
+
+.banner {
+  max-width: var(--container-width);
+  margin-top: 2rem;
+  margin-left: auto;
+  margin-right: auto;
+  padding: .5rem 1.5rem;
+  border-color: transparent;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: .5rem;
+  font-weight: 500;
+}
+
+.banner--unverified {
+  color: rgb(146, 64, 14);
+  background-color: rgba(253, 230, 138, .5);
+  border-color: rgb(253, 230, 138);
+}

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -20,6 +20,8 @@ class Project < ApplicationRecord
 
   def verify! = update(verified_at: Time.current)
 
+  def verified? = verified_at.present?
+
   private
 
   def set_slug

--- a/app/views/projects/_unverified_banner.html.erb
+++ b/app/views/projects/_unverified_banner.html.erb
@@ -1,0 +1,3 @@
+<div class="banner banner--unverified">
+  If you are the owner of this project, <a href="mailto:railsstats@railsdesigner.com?subject=I%20want%20to%20get%20verified%20on%20Rails%20Stats&body=name%3A%20<%= project.name %>%0Aid%3A%20<%= project.slug %>">reach out to get verified</a>.
+</div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -18,6 +18,8 @@
   </section>
 </div>
 
+<%= render partial: "unverified_banner", locals: { project: @project.decorate } unless @project.verified? %>
+
 <ul class="stats">
   <% @project.current_snapshot.listable_metrics.map(&:decorate).each do |metric| %>
     <%= render partial: "metrics", locals: { metric: metric } %>


### PR DESCRIPTION
As long as verification is done manually, show a banner to tell project owners to reach out. 🐌

![banner](https://github.com/user-attachments/assets/04219ffc-f870-4ac8-9b4a-7c94ea6ea807)